### PR TITLE
Remove all references to devtoolset 11

### DIFF
--- a/manywheel/Dockerfile_2_28
+++ b/manywheel/Dockerfile_2_28
@@ -7,10 +7,7 @@ ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
-ARG DEVTOOLSET_VERSION=11
-RUN yum install -y wget curl perl util-linux xz bzip2 git patch which perl zlib-devel yum-utils gcc-toolset-${DEVTOOLSET_VERSION}-toolchain
-ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
-ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH
+RUN yum install -y wget curl perl util-linux xz bzip2 git patch which perl zlib-devel yum-utils
 
 # cmake-3.18.4 from pip
 RUN yum install -y python3-pip && \
@@ -61,7 +58,6 @@ ADD ./common/install_libpng.sh install_libpng.sh
 RUN bash ./install_libpng.sh && rm install_libpng.sh
 
 FROM ${GPU_IMAGE} as common
-ARG DEVTOOLSET_VERSION=11
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
@@ -84,7 +80,6 @@ RUN yum install -y \
         wget \
         which \
         xz \
-        gcc-toolset-${DEVTOOLSET_VERSION}-toolchain \
         glibc-langpack-en
 
 RUN yum install -y \
@@ -115,10 +110,6 @@ COPY --from=jni                /usr/local/include/jni.h              /usr/local/
 
 FROM common as cpu_final
 ARG BASE_CUDA_VERSION=11.8
-ARG DEVTOOLSET_VERSION=11
-# Ensure the expected devtoolset is used
-ENV PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/bin:$PATH
-ENV LD_LIBRARY_PATH=/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib64:/opt/rh/gcc-toolset-${DEVTOOLSET_VERSION}/root/usr/lib:$LD_LIBRARY_PATH
 
 # cmake-3.18.4 from pip; force in case cmake3 already exists
 RUN yum install -y python3-pip && \


### PR DESCRIPTION
Tested via: http://ml-ci-internal.amd.com:8080/job/pytorch/job/dev/job/manylinux_rocm_wheels_test/125

With this PR (combined with changes from https://github.com/ROCm/ROCm-docker/pull/135):
```
[2024-07-23T20:45:48.734Z] -- ******** Summary ********
...
[2024-07-23T20:45:48.734Z] --   C++ compiler              : /usr/bin/c++
```

Without this PR:
```
[2024-07-23T13:12:26.465Z] -- ******** Summary ********
...
[2024-07-23T13:12:26.465Z] --   C++ compiler              : /opt/rh/gcc-toolset-11/root/usr/bin/c++
```